### PR TITLE
core: initial provisioning support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,18 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v1
 
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -54,6 +66,12 @@ jobs:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
 
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -63,11 +81,12 @@ jobs:
       - name: Install target
         run: rustup target add ${{ matrix.target }}
 
-      - name: Run cargo build (core)
+      - name: Run cargo build
         working-directory: core
         env:
+          CARGO_INCREMENTAL: 0
           RUSTFLAGS: -D warnings
-        run: cargo build --release --target ${{ matrix.target }} --no-default-features
+        run: cargo build --release --target ${{ matrix.target }}
 
   coverage:
     name: Code Coverage
@@ -160,6 +179,7 @@ jobs:
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         env:
+          CARGO_INCREMENTAL: 0
           RUSTFLAGS: -D warnings
         with:
           command: test
@@ -168,6 +188,7 @@ jobs:
       - name: Run cargo test (--all-features)
         uses: actions-rs/cargo@v1
         env:
+          CARGO_INCREMENTAL: 0
           RUSTFLAGS: -D warnings
         with:
           command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,9 @@ name = "armistice_core"
 version = "0.0.0"
 dependencies = [
  "armistice_schema 0.0.0",
+ "displaydoc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -45,6 +48,26 @@ dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "elliptic-curve 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "p256 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -82,6 +105,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "elliptic-curve 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,8 +129,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "subtle"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -140,13 +181,18 @@ source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#4c874f7
 "checksum as-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "37dfb65bc03b2bc85ee827004f14a6817e04160e3b1a28931986a666a9290e70"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum displaydoc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a06d4ceb0482364a62aa1e4393da51c8aa3229432e8893fe7e3da9f884c97130"
+"checksum ecdsa 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e96b58e5e926181b2cd9bd547b672e888482644a27b5e067e7a13ee52baf5813"
+"checksum elliptic-curve 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01f69be7d1feb7a7a04f158aaf32c7deaa7604e9bd58145525e536438c4e5096"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 "checksum hash32 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
 "checksum heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10b591a0032f114b7a77d4fbfab452660c553055515b7d7ece355db080d19087"
+"checksum p256 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "812a058a5afc96a52a8ab6e250325d025254ff030ff737dc5b62576e4e604c42"
 "checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum signature 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0cfcdc45066661979294e965c21b60355da35eb5d638af8143e5aa83fdfce53"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 "checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,9 +14,15 @@ repository = "https://github.com/iqlusioninc/armistice/tree/develop/core"
 categories = ["cryptography", "hardware-support", "no-std"]
 keywords   = ["bls", "ed25519", "ecdsa", "hsm"]
 
-[dependencies.armistice_schema]
-version = "0"
-path = "../schema"
+[dependencies]
+armistice_schema = { version = "0", path = "../schema" }
+displaydoc = { version = "0.1", default-features = false }
+ecdsa = { version = "0.4", optional = true, default-features = false, features = ["p256"] }
+heapless = "0.5"
+
+[features]
+default = ["ecdsa"]
+std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/src/armistice.rs
+++ b/core/src/armistice.rs
@@ -1,0 +1,45 @@
+//! Armistice Core State
+
+use crate::{
+    crypto::PublicKey,
+    error::Error,
+    root::Root,
+    schema::{self, Request, Response},
+};
+
+/// Armistice Core State
+#[derive(Debug, Default)]
+pub struct Armistice {
+    /// Root configuration
+    root: Root,
+}
+
+impl Armistice {
+    /// Process the given [`Request`], returning a [`Response`] or an [`Error`]
+    pub fn request(&mut self, request: Request) -> Result<Response, Error> {
+        match request {
+            Request::Provision(provision) => self
+                .provision(
+                    provision.root_key_threshold as usize,
+                    provision.root_keys.into_iter().map(Into::into),
+                )
+                .map(Into::into),
+        }
+    }
+
+    /// Perform initial device provisioning
+    pub fn provision(
+        &mut self,
+        threshold: usize,
+        keys: impl IntoIterator<Item = PublicKey>,
+    ) -> Result<schema::provision::Response, Error> {
+        if self.root.is_empty() {
+            self.root = Root::new(threshold, keys)?;
+            Ok(schema::provision::Response {
+                uuid: self.root.uuid(),
+            })
+        } else {
+            Err(Error::Provision)
+        }
+    }
+}

--- a/core/src/crypto.rs
+++ b/core/src/crypto.rs
@@ -1,0 +1,5 @@
+//! Cryptographic functionality
+
+pub mod public_key;
+
+pub use public_key::PublicKey;

--- a/core/src/crypto/public_key.rs
+++ b/core/src/crypto/public_key.rs
@@ -1,0 +1,32 @@
+//! Public key types
+
+use crate::schema;
+
+/// Public keys
+#[derive(Copy, Clone, Debug)]
+pub enum PublicKey {
+    /// ECDSA public keys
+    #[cfg(feature = "ecdsa")]
+    Ecdsa(EcdsaKey),
+
+    /// Ed25519 public keys
+    // TODO(tarcieri): use ed25519-dalek's `PublicKey` type
+    Ed25519([u8; 32]),
+}
+
+// TODO(tarcieri): this should eventually be a `TryFrom`
+impl From<schema::public_key::PublicKey> for PublicKey {
+    fn from(key: schema::public_key::PublicKey) -> PublicKey {
+        match key {
+            schema::public_key::PublicKey::Ed25519(bytes) => PublicKey::Ed25519(bytes),
+        }
+    }
+}
+
+/// ECDSA public keys
+#[derive(Copy, Clone, Debug)]
+pub enum EcdsaKey {
+    /// NIST P-256 public keys
+    #[cfg(feature = "ecdsa")]
+    P256(ecdsa::curve::nistp256::PublicKey),
+}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,19 @@
+//! Error type
+
+use displaydoc::Display;
+
+/// Types of errors
+#[derive(Copy, Clone, Debug, Display, Eq, PartialEq)]
+pub enum Error {
+    /// Crypto error
+    Crypto,
+
+    /// Provisioning error
+    Provision,
+
+    /// Threshold invalid
+    Threshold,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,20 @@
 //! Armistice Core
 
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/armistice_core/0.0.0")]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "std")]
 extern crate std;
+
+mod armistice;
+pub mod crypto;
+mod error;
+mod root;
+
+pub use armistice_schema as schema;
+pub use heapless::{self, String, Vec};
+
+pub use armistice::Armistice;
+pub use error::Error;

--- a/core/src/root.rs
+++ b/core/src/root.rs
@@ -1,0 +1,69 @@
+//! Root configuration: controls sensitive administrative authority
+//!
+//! Inspired by the role of the same name in The Update Framework.
+//! See Section 4.3 of the TUF spec:
+//!
+//! <https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#4-document-formats>
+
+use crate::{crypto::PublicKey, error::Error, schema::provision::Uuid};
+use heapless::Vec;
+
+/// Maximum number of keys allowed for root role
+pub(crate) type MaxKeys = heapless::consts::U8;
+
+/// Root configuration: controls sensitive administrative authority
+// TODO(tarcieri): extract type for threshold key sets
+#[derive(Debug, Default)]
+pub(crate) struct Root {
+    /// Threshold for number of keys required to perform a root action
+    threshold: usize,
+
+    /// Public keys for the root role
+    public_keys: Vec<PublicKey, MaxKeys>,
+}
+
+impl Root {
+    /// Create new [`Root`] configuration
+    pub fn new(threshold: usize, keys: impl IntoIterator<Item = PublicKey>) -> Result<Self, Error> {
+        let mut public_keys = Vec::new();
+
+        for key in keys.into_iter() {
+            public_keys.push(key).map_err(|_| Error::Threshold)?;
+        }
+
+        if threshold < 1 || threshold > public_keys.len() {
+            return Err(Error::Threshold);
+        }
+
+        Ok(Root {
+            threshold,
+            public_keys,
+        })
+    }
+
+    /// Is the [`Root`] role presently empty? (i.e. unprovisioned)
+    pub fn is_empty(&self) -> bool {
+        self.threshold == 0
+    }
+
+    /// Get the threshold of required keys
+    #[allow(dead_code)]
+    pub fn threshold(&self) -> usize {
+        self.threshold
+    }
+
+    /// Get the public keys which are members of the root role
+    #[allow(dead_code)]
+    pub fn public_keys(&self) -> &[PublicKey] {
+        self.public_keys.as_ref()
+    }
+
+    /// Get a UUID which represents this root configuration
+    pub fn uuid(&self) -> Uuid {
+        // TODO(tarcieri): stub!
+        let mut uuid = Uuid::new();
+        uuid.push_str("00000000-0000-0000-0000-000000000000")
+            .unwrap();
+        uuid
+    }
+}

--- a/core/tests/provision.rs
+++ b/core/tests/provision.rs
@@ -1,0 +1,36 @@
+//! Provisioning integration test
+
+use armistice_core::{Armistice, Vec};
+use armistice_schema::{provision, public_key::PublicKey};
+
+#[test]
+fn provisioning_happy_path() {
+    let mut armistice = Armistice::default();
+    let mut root_keys = Vec::new();
+
+    root_keys
+        .push(PublicKey::Ed25519([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ]))
+        .unwrap();
+    root_keys
+        .push(PublicKey::Ed25519([
+            31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+            9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+        ]))
+        .unwrap();
+
+    let request = provision::Request {
+        root_key_threshold: 1,
+        root_keys,
+    };
+
+    let response = armistice.request(request.into()).unwrap();
+
+    // TODO(tarcieri): stub!
+    assert_eq!(
+        response.provision().unwrap().uuid,
+        "00000000-0000-0000-0000-000000000000"
+    );
+}

--- a/schema/src/provision.rs
+++ b/schema/src/provision.rs
@@ -12,6 +12,10 @@ use veriform::{
     vint64, Decodable, Decoder, Encoder, Error, Message,
 };
 
+/// UUID type
+// TODO(tarcieri): define a builtin type for UUIDs that uses the `uuid` crate
+pub type Uuid = String<U36>;
+
 /// Request to provision a device
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Request {
@@ -29,7 +33,7 @@ pub struct Request {
 pub struct Response {
     /// UUID (deterministically) assigned at provisioning time
     // #[field(string, tag = 0, critical = true, size = 36)]
-    pub uuid: String<U36>,
+    pub uuid: Uuid,
 }
 
 // TODO(tarcieri): custom derive support for `veriform::Message`

--- a/schema/src/request.rs
+++ b/schema/src/request.rs
@@ -16,6 +16,23 @@ pub enum Request {
 }
 
 // TODO(tarcieri): custom derive support for `veriform::Message`
+impl Request {
+    /// Get a provisioning request, if this is one
+    pub fn provision(&self) -> Option<&provision::Request> {
+        match self {
+            Request::Provision(provision) => Some(provision),
+        }
+    }
+}
+
+// TODO(tarcieri): custom derive support for `veriform::Message`
+impl From<provision::Request> for Request {
+    fn from(request: provision::Request) -> Request {
+        Request::Provision(request)
+    }
+}
+
+// TODO(tarcieri): custom derive support for `veriform::Message`
 impl Message for Request {
     fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
         let mut bytes = bytes.as_ref();

--- a/schema/src/response.rs
+++ b/schema/src/response.rs
@@ -16,6 +16,22 @@ pub enum Response {
 }
 
 // TODO(tarcieri): custom derive support for `veriform::Message`
+impl Response {
+    /// Get a provisioning request, if this is one
+    pub fn provision(&self) -> Option<&provision::Response> {
+        match self {
+            Response::Provision(provision) => Some(provision),
+        }
+    }
+}
+
+impl From<provision::Response> for Response {
+    fn from(response: provision::Response) -> Response {
+        Response::Provision(response)
+    }
+}
+
+// TODO(tarcieri): custom derive support for `veriform::Message`
 impl Message for Response {
     fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
         let mut bytes = bytes.as_ref();


### PR DESCRIPTION
This commit spikes out an initial skeleton for the core.

It implements (largely as stubs) an initial provisioning request, which can set the root keys, and then returns a response containing a (stub) UUID which will eventually uniquely identify the device.