### PR TITLE
usbarmory: initial crate skeleton

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --workspace --exclude armistice_usbarmory
 
   build:
     name: Build (core)
@@ -88,6 +89,45 @@ jobs:
           RUSTFLAGS: -D warnings
         run: cargo build --release --target ${{ matrix.target }}
 
+  build_usbarmory:
+    name: Build (usbarmory)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install beta toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          target: armv7a-none-eabi
+          toolchain: beta
+          override: true
+
+      - name: Run cargo build
+        working-directory: usbarmory
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
+        run: cargo build --release
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
@@ -116,8 +156,8 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.9.0'
-          args: '-- --test-threads 1'
+          version: 0.9.0
+          args: --all --exclude armistice_usbarmory -- --test-threads 1
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2
@@ -183,7 +223,7 @@ jobs:
           RUSTFLAGS: -D warnings
         with:
           command: test
-          args: --release
+          args: --release  --workspace --exclude armistice_usbarmory
 
       - name: Run cargo test (--all-features)
         uses: actions-rs/cargo@v1
@@ -192,7 +232,7 @@ jobs:
           RUSTFLAGS: -D warnings
         with:
           command: test
-          args: --all-features --release
+          args: --all-features --release  --workspace --exclude armistice_usbarmory
 
   fmt:
     name: Rustfmt
@@ -254,4 +294,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --workspace --exclude armistice_usbarmory -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "armistice_usbarmory"
+version = "0.0.0"
+dependencies = [
+ "armistice_core 0.0.0",
+ "usbarmory 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +47,16 @@ dependencies = [
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "consts"
+version = "0.0.0"
+source = "git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop#6489d964c0c9b74f66f5e575ff6a02bfe41b4819"
+
+[[package]]
+name = "cortex-a"
+version = "0.0.0"
+source = "git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop#6489d964c0c9b74f66f5e575ff6a02bfe41b4819"
 
 [[package]]
 name = "displaydoc"
@@ -105,6 +123,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "imx6ul-pac"
+version = "0.0.0"
+source = "git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop#6489d964c0c9b74f66f5e575ff6a02bfe41b4819"
+
+[[package]]
+name = "memlog"
+version = "0.0.0"
+source = "git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop#6489d964c0c9b74f66f5e575ff6a02bfe41b4819"
+dependencies = [
+ "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imx6ul-pac 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+]
+
+[[package]]
 name = "p256"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +159,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "signature"
@@ -164,6 +201,37 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "usb-device"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "usbarmory"
+version = "0.0.0"
+source = "git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop#6489d964c0c9b74f66f5e575ff6a02bfe41b4819"
+dependencies = [
+ "consts 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+ "cortex-a 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+ "heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imx6ul-pac 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+ "memlog 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "usb-device 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "usbarmory-rt 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+]
+
+[[package]]
+name = "usbarmory-rt"
+version = "0.0.0"
+source = "git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop#6489d964c0c9b74f66f5e575ff6a02bfe41b4819"
+dependencies = [
+ "cortex-a 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+ "imx6ul-pac 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "veriform"
 version = "0.0.1"
 source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#4c874f7fd3ed0753a723258bc9b23386da6461ba"
@@ -180,6 +248,8 @@ source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#4c874f7
 [metadata]
 "checksum as-slice 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "37dfb65bc03b2bc85ee827004f14a6817e04160e3b1a28931986a666a9290e70"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+"checksum consts 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)" = "<none>"
+"checksum cortex-a 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)" = "<none>"
 "checksum displaydoc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a06d4ceb0482364a62aa1e4393da51c8aa3229432e8893fe7e3da9f884c97130"
 "checksum ecdsa 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e96b58e5e926181b2cd9bd547b672e888482644a27b5e067e7a13ee52baf5813"
 "checksum elliptic-curve 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01f69be7d1feb7a7a04f158aaf32c7deaa7604e9bd58145525e536438c4e5096"
@@ -187,14 +257,20 @@ source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#4c874f7
 "checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 "checksum hash32 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
 "checksum heapless 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10b591a0032f114b7a77d4fbfab452660c553055515b7d7ece355db080d19087"
+"checksum imx6ul-pac 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)" = "<none>"
+"checksum memlog 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)" = "<none>"
 "checksum p256 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "812a058a5afc96a52a8ab6e250325d025254ff030ff737dc5b62576e4e604c42"
 "checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum signature 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0cfcdc45066661979294e965c21b60355da35eb5d638af8143e5aa83fdfce53"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 "checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum usb-device 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e5e2b9ba23f0d9ef7a34e498b6581c9d67944a1916542bfc7238bf1dc0d6acd"
+"checksum usbarmory 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)" = "<none>"
+"checksum usbarmory-rt 0.0.0 (git+https://github.com/iqlusioninc/usbarmory.rs.git?branch=develop)" = "<none>"
 "checksum veriform 0.0.1 (git+https://github.com/iqlusioninc/veriform.git?branch=develop)" = "<none>"
 "checksum vint64 0.2.1 (git+https://github.com/iqlusioninc/veriform.git?branch=develop)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["core", "client", "schema"]
+members = [
+    "core",
+    "client",
+    "schema",
+    "usbarmory"
+]
 
 [patch.crates-io]
 veriform = { git = "https://github.com/iqlusioninc/veriform.git", branch = "develop" }

--- a/client/README.md
+++ b/client/README.md
@@ -16,7 +16,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
 ## Minimum Supported Rust Version
 
-Rust **1.39**
+Rust **1.40**
 
 ## Security Warning
 
@@ -60,6 +60,6 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.39+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community

--- a/core/README.md
+++ b/core/README.md
@@ -16,7 +16,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
 ## Minimum Supported Rust Version
 
-Rust **1.39**
+Rust **1.40**
 
 ## Security Warning
 
@@ -60,6 +60,6 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.39+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community

--- a/schema/README.md
+++ b/schema/README.md
@@ -16,7 +16,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
 ## Minimum Supported Rust Version
 
-- Rust **1.39**
+- Rust **1.40**
 
 ## Security Warning
 
@@ -60,6 +60,6 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.39+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community

--- a/usbarmory/.cargo/config
+++ b/usbarmory/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "armv7a-none-eabi"

--- a/usbarmory/Cargo.toml
+++ b/usbarmory/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "armistice_usbarmory"
+description = """
+Armistice for USB armory MkII: hardware private key storage application for
+next-generation cryptography (e.g. BLS)
+"""
+version    = "0.0.0"
+license    = "Apache-2.0"
+authors    = ["Tony Arcieri <bascule@gmail.com>"]
+edition    = "2018"
+readme     = "README.md"
+homepage   = "https://github.com/iqlusioninc/armistice/"
+repository = "https://github.com/iqlusioninc/armistice/tree/develop/usbarmory"
+categories = ["cryptography", "hardware-support", "no-std"]
+keywords   = ["bls", "ed25519", "ecdsa", "hsm"]
+
+[dependencies]
+armistice_core = { version = "0", path = "../core" }
+usbarmory = { version = "0", git = "https://github.com/iqlusioninc/usbarmory.rs.git", branch = "develop" }

--- a/usbarmory/README.md
+++ b/usbarmory/README.md
@@ -1,4 +1,4 @@
-# Armistice <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-production-web/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a>
+# Armistice for USB armory MkII <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-production-web/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a>
 
 [![Build Status][build-image]][build-link]
 [![Safety Dance][safety-image]][safety-link]
@@ -32,7 +32,7 @@ stage and will not be ready to use for some time.
 
 ## License
 
-Copyright © 2019-2020 iqlusion
+Copyright © 2020 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/usbarmory/src/lib.rs
+++ b/usbarmory/src/lib.rs
@@ -1,0 +1,6 @@
+//! Armistice Core
+
+#![no_std]
+#![doc(html_root_url = "https://docs.rs/armistice_usbarmory/0.0.0")]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
Adds an initial skeleton for Armistice + USB armory MkII integration.

Right now it just pulls `armistice_core` and the `usbarmory` crate into the same project and tries to build it with the `beta` Rust compiler on the `armv7a-none-eabi` target.