### PR TITLE
Use 1.42 as the MSRV across the board

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,8 +49,7 @@ jobs:
           - thumbv7em-none-eabihf
           - wasm32-unknown-unknown
         toolchain:
-          - 1.40.0
-          - stable
+          - beta
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -185,8 +184,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.40.0
-          - stable
+          - beta
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Armistice <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-production-web/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a> [![Build Status][build-image]][build-link] [![Safety Dance][safety-image]][safety-link] [![Apache 2.0 Licensed][license-image]][license-link] ![MSRV][msrv-image] [![Gitter Chat][gitter-image]][gitter-link]
 
-Hardware private key storage for next-generation cryptography (e.g. BLS)
-initially targeting [USB armory Mk II devices] from [F-Secure].
+Hardware private key storage for next-generation cryptography (e.g. BLS).
+
+Initially targeting [USB armory Mk II devices] from [F-Secure].
 
 ## Minimum Supported Rust Version
 
-- Rust **1.40**
+- Rust **1.42**
 
 ## Security Warning
 
@@ -54,7 +55,7 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.42+-red.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 

--- a/client/README.md
+++ b/client/README.md
@@ -4,7 +4,7 @@ Hardware private key storage for next-generation cryptography (e.g. BLS)
 
 ## Minimum Supported Rust Version
 
-- Rust **1.40**
+- Rust **1.42**
 
 ## Security Warning
 
@@ -53,7 +53,7 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.42+-red.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 

--- a/core/README.md
+++ b/core/README.md
@@ -4,7 +4,7 @@ Hardware private key storage for next-generation cryptography (e.g. BLS)
 
 ## Minimum Supported Rust Version
 
-- Rust **1.40**
+- Rust **1.42**
 
 ## Security Warning
 
@@ -53,7 +53,7 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.42+-red.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -4,7 +4,7 @@ Hardware private key storage for next-generation cryptography (e.g. BLS)
 
 ## Minimum Supported Rust Version
 
-- Rust **1.40**
+- Rust **1.42**
 
 ## Security Warning
 
@@ -53,7 +53,7 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.42+-red.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 


### PR DESCRIPTION
We'll need it for the `usbarmory` target, so might as well adopt it across the board as our MSRV.

Stable release is due March 12th.