### PR TITLE
client: add basic testing support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,8 +45,8 @@ jobs:
     strategy:
       matrix:
         target:
-          - armv7-unknown-linux-musleabihf
-          - thumbv7em-none-eabihf
+          - armv7a-none-eabi
+          - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
           - beta

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings", "cryptography", "hardware-support"]
 keywords   = ["bls", "ed25519", "ecdsa", "hsm"]
 
 [dependencies]
-anyhow = "1.0.26"
+anyhow = "1"
 armistice_schema = { version = "0", path = "../schema" }
 consts = { optional = true, git = "https://github.com/iqlusioninc/usbarmory.rs.git", branch = "develop" }
 rusb = { version = "0.5", optional = true }

--- a/client/README.md
+++ b/client/README.md
@@ -24,6 +24,19 @@ stage and will not be ready to use for some time.
 If you are interested in contributing to this repository, please make sure to
 read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
+### Running tests
+
+This crate includes tests which run interactively against a USB armory MkII
+device which is expected to be running Armistice Core built from the same
+commit as the client tests.
+
+Since we can't run these tests in CI (since there's no device to communicate
+with) these tests are flagged with `#[ignore]` and must be run with:
+
+```
+$ cargo test -- --ignored
+```
+
 ## License
 
 Copyright © 2019-2020 iqlusion

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,4 +1,7 @@
 //! Armistice Client
 
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
 #[cfg(feature = "usbarmory")]
 pub mod usbarmory;

--- a/client/tests/integration.rs
+++ b/client/tests/integration.rs
@@ -1,0 +1,20 @@
+//! Armistice client integration tests
+//!
+//! Tests which require a USB armory MkII device running Armistice Core in
+//! order to pass are tagged with `#[ignore]` and must be run with:
+//!
+//! ```text
+//! $ cargo test -- --ignored
+//! ```
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[test]
+#[ignore]
+fn echo() {
+    let results = armistice::usbarmory::run(&["testing", "123"]).unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0], "gnitset");
+    assert_eq!(results[1], "321");
+}


### PR DESCRIPTION
Adds an end-to-end integration test for USB communication, using the current USB example (which reverses strings sent to it).