### PR TITLE
core: remove generic parameter from RootKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 [[package]]
 name = "aes-gcm-siv"
 version = "0.3.0"
-source = "git+https://github.com/RustCrypto/AEADs.git#607ee849824ae41f12f6c7b48daa49e68d6c1c97"
+source = "git+https://github.com/RustCrypto/AEADs.git#282133113bc0f8bf13888f5af454a0596f7fae9f"
 dependencies = [
  "aead",
  "block-cipher-trait",

--- a/core/src/armistice.rs
+++ b/core/src/armistice.rs
@@ -1,10 +1,7 @@
 //! Armistice core state
 
 use crate::{
-    crypto::{
-        public_key::PublicKey,
-        root_key::{Ctr, RootKey},
-    },
+    crypto::{PublicKey, RootKey},
     error::Error,
     root,
     schema::{self, Request, Response},
@@ -15,24 +12,22 @@ use block_cipher_trait::{
 };
 
 /// Armistice Core State
-pub struct Armistice<B, C>
+pub struct Armistice<B>
 where
     B: BlockCipher<BlockSize = U16>,
     B::ParBlocks: ArrayLength<GenericArray<u8, B::BlockSize>>,
-    C: Ctr<B>,
 {
     /// Root configuration
     root_config: root::Config,
 
     /// Root symmetric key
-    root_key: RootKey<B, C>,
+    root_key: RootKey<B>,
 }
 
-impl<B, C> Armistice<B, C>
+impl<B> Armistice<B>
 where
     B: BlockCipher<BlockSize = U16>,
     B::ParBlocks: ArrayLength<GenericArray<u8, B::BlockSize>>,
-    C: Ctr<B>,
 {
     /// Create new [`Armistice`] core state
     pub fn new(root_key: B) -> Self {
@@ -48,7 +43,7 @@ where
     }
 
     /// Get the [`RootKey`]
-    pub fn root_key(&self) -> &RootKey<B, C> {
+    pub fn root_key(&self) -> &RootKey<B> {
         &self.root_key
     }
 

--- a/core/src/crypto/root_key.rs
+++ b/core/src/crypto/root_key.rs
@@ -1,7 +1,6 @@
 //! Root key
 
-pub use aes_gcm_siv::ctr::*;
 use aes_gcm_siv::AesGcmSiv;
 
 /// Root AES-GCM-SIV key
-pub type RootKey<B, C> = AesGcmSiv<B, C>;
+pub type RootKey<B> = AesGcmSiv<B>;

--- a/core/tests/provision.rs
+++ b/core/tests/provision.rs
@@ -1,11 +1,10 @@
 //! Provisioning integration test
 
 use aes::{block_cipher_trait::BlockCipher, Aes128};
-use aes_gcm_siv::ctr::Ctr32x8;
 use armistice_core::Vec;
 use armistice_schema::{provision, public_key::PublicKey};
 
-type Armistice = armistice_core::Armistice<Aes128, Ctr32x8<Aes128>>;
+type Armistice = armistice_core::Armistice<Aes128>;
 
 #[test]
 fn provisioning_happy_path() {

--- a/usbarmory/src/main.rs
+++ b/usbarmory/src/main.rs
@@ -7,10 +7,7 @@
 #![deny(warnings, rust_2018_idioms, unused_qualifications)]
 #![forbid(unsafe_code)]
 
-use armistice_core::{
-    crypto::root_key::Ctr32,
-    schema::{Message, Request},
-};
+use armistice_core::schema::{Message, Request};
 use core::time::Duration;
 use exception_reset as _; // default exception handler
 use heapless::pool::singleton::{Box, Pool};
@@ -31,7 +28,7 @@ const MAX_PACKET_SIZE: u16 = 512;
 heapless::pool!(P: [u8; MAX_PACKET_SIZE as usize]);
 
 /// Armistice instantiated with USB armory types
-type Armistice = armistice_core::Armistice<Aes128, Ctr32<Aes128>>;
+type Armistice = armistice_core::Armistice<Aes128>;
 
 #[rtfm::app()]
 const APP: () = {


### PR DESCRIPTION
Eliminated by making the CTR mode implementation generic around the number of AES blocks computed in parallel.