### PR TITLE
Upgrade `aes-gcm-siv` dependency to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,8 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.3.0"
-source = "git+https://github.com/RustCrypto/AEADs.git#282133113bc0f8bf13888f5af454a0596f7fae9f"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a767d8be24e65ca2ff9c57be55f0849eba8886d8229807afaecfe7bd00ffff2"
 dependencies = [
  "aead",
  "block-cipher-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ members = [
 ]
 
 [patch.crates-io]
-aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs.git" }
 veriform = { git = "https://github.com/iqlusioninc/veriform.git", branch = "develop" }
 
 [profile.release]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "hardware-support", "no-std"]
 keywords   = ["bls", "ed25519", "ecdsa", "hsm"]
 
 [dependencies]
-aes-gcm-siv = { version = "0.3", default-features = false, features = ["heapless"] }
+aes-gcm-siv = { version = "0.4", default-features = false, features = ["heapless"] }
 armistice_schema = { version = "0", path = "../schema" }
 block-cipher-trait = "0.6"
 displaydoc = { version = "0.1", default-features = false }


### PR DESCRIPTION
Uses the release version, instead of git.