### PR TITLE
Update Veriform to 4754f8b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 [[package]]
 name = "veriform"
 version = "0.0.1"
-source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#222f3f3c014a39a9f32d8be5e98e44d6db8e7c1a"
+source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#4754f8bbcd6398096ef5fde0498391229f10497c"
 dependencies = [
  "digest",
  "displaydoc",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "vint64"
 version = "1.0.1"
-source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#222f3f3c014a39a9f32d8be5e98e44d6db8e7c1a"
+source = "git+https://github.com/iqlusioninc/veriform.git?branch=develop#4754f8bbcd6398096ef5fde0498391229f10497c"
 
 [[package]]
 name = "winapi"

--- a/client/tests/integration.rs
+++ b/client/tests/integration.rs
@@ -23,9 +23,15 @@ fn perform_provisioning() {
     let mut root_keys = provision::RootKeys::new();
     root_keys.push(PublicKey::Ed25519([0u8; 32])).unwrap();
 
+    let digest = [
+        62, 123, 47, 254, 135, 49, 169, 234, 97, 122, 186, 151, 131, 201, 204, 233, 10, 95, 192,
+        185, 47, 98, 107, 121, 143, 244, 221, 127, 183, 159, 183, 187,
+    ];
+
     let request = provision::Request {
         root_key_threshold: 1,
         root_keys,
+        digest,
     };
     let response = armistice.send_request(request).unwrap();
     dbg!(&response);

--- a/core/tests/provision.rs
+++ b/core/tests/provision.rs
@@ -32,9 +32,15 @@ fn provisioning_happy_path() {
         ]))
         .unwrap();
 
+    let digest = [
+        62, 123, 47, 254, 135, 49, 169, 234, 97, 122, 186, 151, 131, 201, 204, 233, 10, 95, 192,
+        185, 47, 98, 107, 121, 143, 244, 221, 127, 183, 159, 183, 187,
+    ];
+
     let request = provision::Request {
         root_key_threshold: 1,
         root_keys,
+        digest,
     };
 
     let response = armistice.handle_request(request.into()).unwrap();

--- a/schema/src/provision.rs
+++ b/schema/src/provision.rs
@@ -24,6 +24,10 @@ pub struct Request {
     /// Root keys used to manage domains
     // #[field(sequence(message), tag = 1, critical = true, max = 8)]
     pub root_keys: RootKeys,
+
+    /// Digest of this message (to be signed by each of the root keys)
+    // #[digest(sha256)]
+    pub digest: [u8; 32],
 }
 
 /// Response to a device being provisioned
@@ -53,9 +57,13 @@ impl Message for Request {
             })?;
         }
 
+        let mut digest = [0u8; 32];
+        decoder.fill_digest(&mut digest)?;
+
         Ok(Self {
             root_key_threshold,
             root_keys,
+            digest,
         })
     }
 
@@ -134,9 +142,15 @@ pub(crate) mod tests {
             ]))
             .unwrap();
 
+        let digest = [
+            62, 123, 47, 254, 135, 49, 169, 234, 97, 122, 186, 151, 131, 201, 204, 233, 10, 95,
+            192, 185, 47, 98, 107, 121, 143, 244, 221, 127, 183, 159, 183, 187,
+        ];
+
         Request {
             root_key_threshold: 1,
             root_keys,
+            digest,
         }
     }
 


### PR DESCRIPTION
This commit adds initial support for embedding message hashes (computed at the time the message was decoded) into the message types themselves.