### PR TITLE
schema: add provisioning timestamp

### DIFF
--- a/client/tests/integration.rs
+++ b/client/tests/integration.rs
@@ -11,7 +11,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 use armistice::{
-    schema::{provision, public_key::PublicKey},
+    schema::{provision, PublicKey, Timestamp},
     Armistice,
 };
 
@@ -23,11 +23,17 @@ fn perform_provisioning() {
     let mut root_keys = provision::RootKeys::new();
     root_keys.push(PublicKey::Ed25519([0u8; 32])).unwrap();
 
+    // TAI64N for 2020-05-21
+    let timestamp =
+        Timestamp::from_slice(&[64, 0, 0, 0, 94, 198, 207, 194, 32, 254, 206, 208]).unwrap();
+
     let request = provision::Request {
         root_key_threshold: 1,
         root_keys,
+        timestamp,
         digest: None,
     };
+
     let response = armistice.send_request(request).unwrap();
     dbg!(&response);
 }

--- a/core/tests/provision.rs
+++ b/core/tests/provision.rs
@@ -2,7 +2,7 @@
 
 use aes::{block_cipher_trait::BlockCipher, Aes128};
 use armistice_core::Vec;
-use armistice_schema::{provision, public_key::PublicKey, Uuid};
+use armistice_schema::{provision, public_key::PublicKey, Timestamp, Uuid};
 
 type Armistice = armistice_core::Armistice<Aes128>;
 
@@ -32,9 +32,14 @@ fn provisioning_happy_path() {
         ]))
         .unwrap();
 
+    // TAI64N for 2020-05-21
+    let timestamp =
+        Timestamp::from_slice(&[64, 0, 0, 0, 94, 198, 207, 194, 32, 254, 206, 208]).unwrap();
+
     let request = provision::Request {
         root_key_threshold: 1,
         root_keys,
+        timestamp,
         digest: None,
     };
 

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -11,4 +11,8 @@ pub mod request;
 pub mod response;
 
 pub use self::{public_key::PublicKey, request::Request, response::Response};
-pub use veriform::{self, builtins::Uuid, Message};
+pub use veriform::{
+    self,
+    builtins::{Timestamp, Uuid},
+    Message,
+};


### PR DESCRIPTION
Adds a time when provisioning is said to have occurred. This timestamp will be included in the message hash which is signed by all root keys.