### PR TITLE
.github/workflows/rust.yml: use 1.43.0 toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
         toolchain:
-          - 1.42.0 # MSRV
+          - 1.43.0 # MSRV
           - stable
     steps:
       - name: Checkout sources
@@ -140,7 +140,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.42.0 # MSRV
+          - 1.43.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Bump Rust toolchain to fix [CI failure.](https://github.com/iqlusioninc/armistice/pull/133/checks?check_run_id=854103639) 

https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html